### PR TITLE
Add front-matter with relevant metadata (no content changes)

### DIFF
--- a/cookie-policy.md
+++ b/cookie-policy.md
@@ -1,3 +1,7 @@
+---
+title: Cookie Policy
+slug: /information/tos/cookie-policy/
+---
 # Cookie Policy
 
 Last updated: May 25th, 2018

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,4 +1,8 @@
-# Privacy policy
+---
+title: Privacy Policy
+slug: /information/tos/privacy-policy/
+---
+# Privacy Policy
 
 Effective date: May 25th, 2018
 

--- a/terms-of-service.md
+++ b/terms-of-service.md
@@ -1,3 +1,7 @@
+---
+title: Terms of Service
+slug: /information/tos/
+---
 # Terms of Service
 
 Last updated: May 25th, 2018


### PR DESCRIPTION
We don't have a direct mapping between URL and these files. So add some metadata for it. The title seems to duplicate the title in-document, but it is used for the `<title>` of the page.

Also, instead of `slug`, I could call the meta `path` instead, it's just Gatsby that calls this particular mapping `slug`, so I went with that.