### PR TITLE
add trello/google privacy policy links

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -4,7 +4,7 @@ slug: /information/tos/privacy-policy/
 ---
 # Privacy Policy
 
-Effective date: February 19th, 2020
+Effective date: March 15th, 2020
 
 This Privacy Statement (the "Privacy Statement") is provided by:
 
@@ -182,7 +182,9 @@ displayed in the web page. We may store non-personal/non-restricted
 information (eg. content id and access date) in a local browser storage
 to display lists of recent opened integrations. Restricted metadata
 is always stored by the services themselves and requires explicit consent
-given by the facing user to fetch it. 
+given by the facing user to fetch it. The implementation is in compliance with
+the services privacy policies: [Google Privacy Policy](http://www.google.com/policies/privacy) and
+[Trello Privacy policy](https://www.atlassian.com/legal/privacy-policy)
 > The information may be used for the purposes of operating our
 > website and providing our services. This is required to deliver the Service to
 > you as user, by taking steps, at your request, to enter into and to


### PR DESCRIPTION
Add links to the privacy policies of Google (Youtube/Google) and Trello (Atlassian).

This change is required by using the YouTube api, but is otherwise nice to include for other services as well.

https://developers.google.com/youtube/terms/developer-policies#a.-api-client-terms-of-use-and-privacy-policies