### PR TITLE
fix: ToS outdated links

### DIFF
--- a/cookie-policy.md
+++ b/cookie-policy.md
@@ -50,7 +50,7 @@ cookies. If you block cookies, you may not be able to use all the
 features on our website, or have a worse experience. We have gathered
 information about how you can block and delete cookies and local
 storage elements in this
-[FAQ article](https://support.whereby.com/article/353-policies).
+[FAQ article](https://whereby.helpscoutdocs.com/article/527-policies).
 
 ## How we use cookies and local storage
 
@@ -73,7 +73,7 @@ We use cookies for the following purposes:
 | Advertising                 | We may use cookies and similar tracking technologies of third parties, to learn whether someone who saw an ad in a marketing platform later visited our site and took an action (e.g. created an account or upgraded to a paid plan), and provide our advertising partners with information about how the ad performed. We may also work with advertising partners to show you an ad off Whereby, after you've visited our site or application. |
 
 For the full list of cookies that Whereby and our providers use, see
-our [up-to-date cookie list](https://support.whereby.com/article/353-policies#cookies).
+our [up-to-date cookie list](https://whereby.helpscoutdocs.com/article/527-policies#cookies).
 
 ## Integrations
 

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -369,7 +369,7 @@ Our data protection officer's contact details are: Arne Gleditsch,
 privacy@whereby.com
 
 To learn more, visit the
-[Privacy section in our FAQ](https://support.whereby.com/category/186-privacy).
+[Privacy section in our FAQ](https://whereby.helpscoutdocs.com/article/526-data-storage-and-security).
 
 For any questions about this privacy policy, please contact
 legal@whereby.com.

--- a/terms-of-service.md
+++ b/terms-of-service.md
@@ -38,7 +38,7 @@ We may change these Terms at any time. We keep a historical record of
 all changes to our Terms on [GitHub](https://github.com/whereby/policy). If a change is material, we’ll let
 you know before it takes effect provided that we have your correct
 email address. By using Whereby on or after that effective date, you
-agree to the new Terms. If you don’t agree to them, you should [delete your account](https://whereby.helpscoutdocs.com/article/349-manage-your-account-profile-and-data)
+agree to the new Terms. If you don’t agree to them, you should [delete your account](https://whereby.helpscoutdocs.com/article/488-delete-account)
  before they take effect, otherwise your use of the
 Service and Content will be subject to the new Terms. For paid
 versions of the Services or Content that you have already purchased,
@@ -299,7 +299,7 @@ period. The Company reserves the right to terminate the Service and
 the agreement with you with immediate effect upon written notice to
 you. Users of the paid plans may be entitled to refunds and to
 the extent this is described on our [Support Center](https://support.whereby.com). No users are entitled to refunds upon termination due to breach of
-these Terms. What we consider Fair Use is described in our Support Center. We reserve the right to terminate accounts with usage that exceed the [Fair Use Policy](https://whereby.helpscoutdocs.com/article/353-policies). 
+these Terms. What we consider Fair Use is described in our Support Center. We reserve the right to terminate accounts with usage that exceed the [Fair Use Policy](https://whereby.helpscoutdocs.com/article/527-policies#fair-use).
 
 
 ## 10. Miscellaneous


### PR DESCRIPTION
Some links to our support pages were broken. This PR replaces the old links with the correct ones.